### PR TITLE
📝 #30 글로벌스타일 및 기본레이아웃 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
+        "styled-components": "^6.1.0",
+        "styled-reset": "^4.5.1",
         "web-vitals": "^2.1.4"
       }
     },
@@ -2399,6 +2401,24 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -4222,6 +4242,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
     },
+    "node_modules/@types/stylis": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.2.tgz",
+      "integrity": "sha512-Rm17MsTpQQP5Jq4BF7CdrxJsDufoiL/q5IbJZYZmOZAJALyijgF7BzLgobXUqraNcQdqFYLYGeglDp6QzaxPpg=="
+    },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.9",
       "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.9.tgz",
@@ -5598,6 +5623,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -6102,6 +6135,14 @@
         "postcss": "^8.4"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-declaration-sorter": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
@@ -6282,6 +6323,16 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
     },
     "node_modules/css-tree": {
       "version": "1.0.0-alpha.37",
@@ -15002,6 +15053,11 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -15498,6 +15554,44 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/styled-components": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.0.tgz",
+      "integrity": "sha512-VWNfYYBuXzuLS/QYEeoPgMErP26WL+dX9//rEh80B2mmlS1yRxRxuL5eax4m6ybYEUoHWlTy2XOU32767mlMkg==",
+      "dependencies": {
+        "@emotion/is-prop-valid": "^1.2.1",
+        "@emotion/unitless": "^0.8.0",
+        "@types/stylis": "^4.0.2",
+        "css-to-react-native": "^3.2.0",
+        "csstype": "^3.1.2",
+        "postcss": "^8.4.31",
+        "shallowequal": "^1.1.0",
+        "stylis": "^4.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0"
+      }
+    },
+    "node_modules/styled-reset": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.5.1.tgz",
+      "integrity": "sha512-6EvFWZRwaFRFxiPYMwmnzOe33rDkw5r9jIU0eEi49bkt6VSrvjeMp2ZOw/YFbw5SVs81llIY+5fzHtR2/VBZfQ==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "styled-components": ">=4.0.0 || >=5.0.0 || >=6.0.0"
+      }
+    },
     "node_modules/stylehacks": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
@@ -15512,6 +15606,11 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.0.tgz",
+      "integrity": "sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ=="
     },
     "node_modules/sucrase": {
       "version": "3.34.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
+    "styled-components": "^6.1.0",
+    "styled-reset": "^4.5.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,16 @@
+import { ThemeProvider } from "styled-components";
+import BasicLayout from "./styles/BasicLayout";
+import GlobalStyle from "./styles/GlobalStyle";
+import Theme from "./styles/Theme";
+
 function App() {
   return (
-    <div>
-      hello world
-    </div>
+    <>
+      <ThemeProvider theme={Theme}>
+        <GlobalStyle />
+        <BasicLayout>여기에 컴포넌트 넣어서 테스트하면 됩니다</BasicLayout>
+      </ThemeProvider>
+    </>
   );
 }
 export default App;

--- a/src/styles/BasicLayout.jsx
+++ b/src/styles/BasicLayout.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import styled from "styled-components";
+
+const BasicContainer = styled.div`
+  margin: 0 auto;
+  max-width: 390px;
+  min-height: 100vh;
+  height: 100%;
+  box-shadow: rgb(0 0 0 / 14%) 0px 0px 7px;
+`;
+
+const Screen = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+`;
+
+const BasicLayout = ({ children }) => {
+  return (
+    <BasicContainer>
+      <Screen>{children}</Screen>
+    </BasicContainer>
+  );
+};
+
+export default BasicLayout;

--- a/src/styles/GlobalStyle.jsx
+++ b/src/styles/GlobalStyle.jsx
@@ -1,0 +1,76 @@
+import { createGlobalStyle } from "styled-components";
+import reset from "styled-reset";
+import "./font.css";
+
+const GlobalStyle = createGlobalStyle`
+  ${reset}
+
+  
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  font-size: 14px;
+  font-family: 'GmarketSansMedium';
+}
+
+body {
+  color: inherit;
+  font-weight: 500;
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+ol, ul, li {
+  list-style: none;
+}
+
+button {
+  box-shadow: none;
+  border: none;
+  padding: 0;
+  background-color: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+textarea {
+  border: none;
+  overflow: none;
+  outline: none;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+  resize: none;
+}
+
+button, input, textarea {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+  border: none;
+}
+
+img {
+  width: 100%;
+  vertical-align: middle;
+}
+
+.a11y-hidden { 
+  position: absolute; 
+  width: 1px; 
+  height: 1px; 
+  padding: 0; 
+  margin: -1px; 
+  overflow: hidden; 
+  clip: rect(0, 0, 0, 0); 
+  border: 0;
+}
+`;
+export default GlobalStyle;

--- a/src/styles/Theme.jsx
+++ b/src/styles/Theme.jsx
@@ -1,0 +1,22 @@
+export const colors = {
+  mainColor: "#40A6DE",
+  disabledColor: "#9ACEF8",
+  placeHolderColor: "#DBDBDB",
+  textColor: "#767676",
+  blackColor: "#000000",
+  alertColor: "#EB5757",
+};
+
+export const fontSize = {
+  xsmall: "0.625rem",
+  small: " 0.6875rem",
+  medium: "0.875rem",
+  large: "1.5rem",
+};
+
+const Theme = {
+  colors,
+  fontSize,
+};
+
+export default Theme;

--- a/src/styles/font.css
+++ b/src/styles/font.css
@@ -1,0 +1,20 @@
+@font-face {
+  font-family: "GmarketSansLight";
+  src: url("../assets/fonts/GMARKETSANSLIGHT.OTF") format("opentype");
+  font-weight: 300;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "GmarketSansMedium";
+  src: url("../assets/fonts/GMARKETSANSMEDIUM.OTF") format("opentype");
+  font-weight: 500;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "GmarketSansBold";
+  src: url("../assets/fonts/GMARKETSANSBOLD.OTF") format("opentype");
+  font-weight: 700;
+  font-style: normal;
+}


### PR DESCRIPTION
# ⚡ PR 요약
글로벌스타일 및 기본레이아웃 추가

# 🔍 주요 변경 사항
- styled-components, reset-css 모듈 추가
- styled 폴더 생성 및 font.css, GlobalStyle.jsx, Theme.jsx, BasicLayout.jsx 추가
- App.js에 글로벌스타일, 테마, 기본레이아웃 추가

# 💡 관련 이슈
Resolve #30
