### PR TITLE
🔨  팔로잉, 팔로우 본인 계정 버튼 미표시

### DIFF
--- a/src/pages/Follow/Followers.jsx
+++ b/src/pages/Follow/Followers.jsx
@@ -7,6 +7,10 @@ import {
   setUnFollowUser,
 } from "../../api/follow";
 
+import { useRecoilValue } from "recoil";
+
+import { userInfoAtom } from "../../recoil/userAtom";
+
 import FollowerHeader from "../../components/common/Header/FollowerHeader";
 import FollowerList from "./FollowList/FollowerList";
 import ButtonContainer from "../../components/common/Button/ButtonContainer";
@@ -16,6 +20,7 @@ import NoFollowHome from "../Home/NoFollowHome";
 
 export default function Followers() {
   const { accountname } = useParams();
+  const userInfo = useRecoilValue(userInfoAtom);
 
   const [follower, setFollower] = useState([]);
   const [follow, setFollow] = useState(follower.isfollow);
@@ -71,7 +76,7 @@ export default function Followers() {
                       >
                         취소
                       </ButtonContainer>
-                    ) : (
+                    ) : userInfo.accountname === follower.accountname ? null : (
                       <ButtonContainer
                         width={"65px"}
                         height={"28px"}

--- a/src/pages/Follow/Following.jsx
+++ b/src/pages/Follow/Following.jsx
@@ -7,6 +7,9 @@ import {
   setUnFollowUser,
 } from "../../api/follow";
 
+import { useRecoilValue } from "recoil";
+import { userInfoAtom } from "../../recoil/userAtom";
+
 import FollowingHeader from "../../components/common/Header/FollowingHeader";
 import FollowerList from "./FollowList/FollowerList";
 import ButtonContainer from "../../components/common/Button/ButtonContainer";
@@ -16,6 +19,7 @@ import Loading from "../Loading/Loading";
 
 export default function Following() {
   const { accountname } = useParams();
+  const userInfo = useRecoilValue(userInfoAtom);
 
   const [following, setFollowing] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -79,7 +83,8 @@ export default function Following() {
                       >
                         취소
                       </ButtonContainer>
-                    ) : (
+                    ) : userInfo.accountname ===
+                      following.accountname ? null : (
                       <ButtonContainer
                         width={"65px"}
                         height={"28px"}


### PR DESCRIPTION
# ⚡ PR 요약
팔로잉, 팔로우 본인 계정 버튼 미표시

# 🔍 주요 변경 사항
1. 타 계정 팔로워, 팔로잉 목록 본인 계정 버튼 미표시

# 💡 관련 이슈
Resolve #160
